### PR TITLE
Fix frame size comparison

### DIFF
--- a/target/min.c
+++ b/target/min.c
@@ -170,7 +170,7 @@ static struct transport_frame *transport_fifo_push(struct min_context *self, uin
     // A frame is only queued if there aren't too many frames in the FIFO and there is space in the
     // data ring buffer.
     struct transport_frame *ret = 0;
-    if(self->transport_fifo.n_frames < TRANSPORT_FIFO_MAX_FRAMES) {
+    if (self->transport_fifo.n_frames <= TRANSPORT_FIFO_MAX_FRAMES) {
         // Is there space in the ring buffer for the frame payload?
         if(self->transport_fifo.n_ring_buffer_bytes <= TRANSPORT_FIFO_MAX_FRAME_DATA - data_size) {
             self->transport_fifo.n_frames++;

--- a/target/min.c
+++ b/target/min.c
@@ -575,7 +575,7 @@ void min_poll(struct min_context *self, uint8_t *buf, uint32_t buf_len)
     if((window_size < TRANSPORT_MAX_WINDOW_SIZE) && (self->transport_fifo.n_frames > window_size)) {
         // There are new frames we can send; but don't even bother if there's no buffer space for them
         struct transport_frame *frame = transport_fifo_get(self, window_size);
-        if(ON_WIRE_SIZE(frame->payload_len) < min_tx_space(self->port)) {
+        if(ON_WIRE_SIZE(frame->payload_len) <= min_tx_space(self->port)) {
             frame->seq = self->transport_fifo.sn_max;
             transport_fifo_send(self, frame);
 

--- a/target/min.c
+++ b/target/min.c
@@ -298,6 +298,11 @@ bool min_queue_frame(struct min_context *self, uint8_t min_id, uint8_t *payload,
     }
 }
 
+bool min_queue_has_space_for_frame(struct min_context *self, uint8_t payload_len) {
+    return self->transport_fifo.n_frames <= TRANSPORT_FIFO_MAX_FRAMES &&
+           self->transport_fifo.n_ring_buffer_bytes <= TRANSPORT_FIFO_MAX_FRAME_DATA - payload_len;
+}
+
 // Finds the frame in the window that was sent least recently
 static struct transport_frame *find_retransmit_frame(struct min_context *self)
 {

--- a/target/min.h
+++ b/target/min.h
@@ -158,6 +158,9 @@ struct min_context {
 #ifdef TRANSPORT_PROTOCOL
 // Queue a MIN frame in the transport queue
 bool min_queue_frame(struct min_context *self, uint8_t min_id, uint8_t *payload, uint8_t payload_len);
+
+// Determine if MIN has space to queue a transport frame
+bool min_queue_has_space_for_frame(struct min_context *self, uint8_t payload_len);
 #endif
 
 // Send a non-transport frame MIN frame


### PR DESCRIPTION
This comparison prevented sending packets which match the length returned from `min_tx_space`