### PR TITLE
More logging

### DIFF
--- a/target/min.c
+++ b/target/min.c
@@ -624,8 +624,20 @@ void min_poll(struct min_context *self, uint8_t const *buf, uint32_t buf_len)
 #endif // TRANSPORT_PROTOCOL
 }
 
+#ifdef VALIDATE_MAX_PAYLOAD
+void min_init_context_validate(struct min_context *self, uint8_t port, void * p_rx_frame_checksum)
+#else
 void min_init_context(struct min_context *self, uint8_t port)
+#endif
 {
+#ifdef ASSERTION_CHECKING
+    assert(self != 0);
+#ifdef VALIDATE_MAX_PAYLOAD
+    // check the provided buffer is large enough. This could be false if MIN_PAYLOAD is defined differently when
+    // compiling calling code and this code.
+    assert((void *)(self->rx_frame_payload_buf + MAX_PAYLOAD) <= p_rx_frame_checksum);
+#endif
+#endif
     // Initialize context
     self->rx_header_bytes_seen = 0;
     self->rx_frame_state = SEARCHING_FOR_SOF;

--- a/target/min.c
+++ b/target/min.c
@@ -311,9 +311,9 @@ static struct transport_frame *find_retransmit_frame(struct min_context *self)
 {
     uint8_t window_size = self->transport_fifo.sn_max - self->transport_fifo.sn_min;
 
-#ifdef ASSERTION_CHECKS
+#ifdef ASSERTION_CHECKING
     assert(window_size > 0);
-    assert(window_size <= self->transport_fifo.nframes);
+    assert(window_size <= self->transport_fifo.n_frames);
 #endif
 
     // Start with the head of the queue and call this the oldest

--- a/target/min.h
+++ b/target/min.h
@@ -194,9 +194,15 @@ void min_tx_byte(uint8_t port, uint8_t byte);
 void min_tx_start(uint8_t port);
 void min_tx_finished(uint8_t port);
 
+// define to validate that MAX_PAYLOAD is defined the same value in calling code and min
+#ifdef VALIDATE_MAX_PAYLOAD
+void min_init_context_validate(struct min_context *self, uint8_t port, void * p_rx_frame_checksum);
+#define min_init_context(self, port) min_init_context_validate(self, port, &(self)->rx_frame_checksum)
+#else
 // Initialize a MIN context ready for receiving bytes from a serial link
 // (Can have multiple MIN contexts)
 void min_init_context(struct min_context *self, uint8_t port);
+#endif
 
 #ifdef MIN_DEBUG_PRINTING
 // Debug print


### PR DESCRIPTION
Added some additional debug logs that help identify when invalid packets or states occur. Additionally, fixes an assertion check, and adds optional assertion to check that MIN_PAYLOAD was defined consistently between calling and called code. I ran into this problem more than once and it is hard to spot because if MIN_PAYLOAD in calling code is less than in min.c sometimes the rest of the struct just gets overwritten, but that isn't always obvious.