### PR TITLE
Make code C89/C90 compatible, enable more warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,17 @@
 cmake_minimum_required(VERSION 3.6)
 project(min)
 set(CMAKE_VERBOSE_MAKEFILE ON)
-set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD 90)
 
 set(SOURCE_FILES
         target/min.c
         target/min.h)
+
+add_compile_options(
+        -Wall
+        -Wextra
+        # -Wpedantic
+)
 
 add_library(min STATIC ${SOURCE_FILES})
 # target_compile_options(min PUBLIC -nostdlib -mcpu=cortex-m0plus -mtune=cortex-m0plus -mthumb -g -O3 -Wall)


### PR DESCRIPTION
I am not the biggest fan of this changes, but I would like to use this project - as unmodified as possible - in some project which is compiled using `-std=c90`. In addition to that, if the code is compiled using C90 and with extra warnings enabled, we can be sure that it will work with the most possible compilations (including, of crouse, C99 and C11 without extra warnings enabled).