### PR TITLE
Fix issue #9. MAX_PAYLOAD warning

### DIFF
--- a/target/min.c
+++ b/target/min.c
@@ -503,14 +503,15 @@ static void rx_byte(struct min_context *self, uint8_t byte)
         self->rx_control = byte;
         crc32_step(&self->rx_checksum, byte);
         if (self->rx_frame_length > 0) {
+            self->rx_frame_state = RECEIVING_PAYLOAD;
+#if (MAX_PAYLOAD != 255)
             // Can reduce the RAM size by compiling limits to frame sizes
-            if (self->rx_frame_length <= MAX_PAYLOAD) {
-                self->rx_frame_state = RECEIVING_PAYLOAD;
-            } else {
+            if (self->rx_frame_length > MAX_PAYLOAD) {
                 // Frame dropped because it's longer than any frame we can buffer
                 min_debug_print("Dropping frame because length %d > MAX_PAYLOAD %d", self->rx_frame_length, MAX_PAYLOAD);
                 self->rx_frame_state = SEARCHING_FOR_SOF;
             }
+#endif
         } else {
             self->rx_frame_state = RECEIVING_CHECKSUM_3;
         }


### PR DESCRIPTION
For context, `MAX_PAYLOAD` is `255` by default, `rx_frame_length` is uint8_t, which means that is limited to 255. When compiling, it issues a warning:

```
/Users/0x3333/Code/g6/deps/min/target/min.c:507:39: warning: comparison is always true due to limited range of data type [-Wtype-limits]
  507 |             if (self->rx_frame_length <= MAX_PAYLOAD) {
      |                                       ^~

```

This PR checks if `MAX_PAYLOAD` is different from 255, and if it is, will check the length of the rx packet being received; if not, will just continue receiving, because the buffer is at its maximum size.

`rx_frame_state = RECEIVING_PAYLOAD` is set by default to simplify the `#if`, as it will be overwritten if rx packet is bigger anyways.
