### PR TITLE
Python host optimizations (bytes_to_hexstr, log formatting, _now_ms) 

### DIFF
--- a/host/min.py
+++ b/host/min.py
@@ -28,7 +28,7 @@ def int32_to_bytes(value: int) -> bytes:
 
 
 def bytes_to_hexstr(bytesequence: bytes) -> str:
-    return "".join(f"{b:02X}" for b in bytesequence)
+    return bytesequence.hex().upper()
 
 
 class MINConnectionError(Exception):

--- a/host/min.py
+++ b/host/min.py
@@ -11,7 +11,7 @@ from struct import pack
 from binascii import crc32
 from threading import Lock
 from time import time
-from logging import getLogger, ERROR
+from logging import getLogger, ERROR, DEBUG, INFO
 from typing import Dict, Optional, List
 
 from serial import Serial, SerialException
@@ -254,14 +254,16 @@ class MINTransport:
             raise ValueError("MIN ID out of range")
         frame = MINFrame(min_id=min_id, payload=payload, transport=False, seq=0)
         on_wire_bytes = self._on_wire_bytes(frame=frame)
-        min_logger.info(
-            "Sending MIN frame, min_id=0x%02X, payload=%s",
-            min_id,
-            bytes_to_hexstr(payload),
-        )
-        min_logger.debug(
-            "Sending MIN frame, on wire bytes=%s", bytes_to_hexstr(on_wire_bytes)
-        )
+        if min_logger.isEnabledFor(INFO):
+            min_logger.info(
+                "Sending MIN frame, min_id=0x%02X, payload=%s",
+                min_id,
+                bytes_to_hexstr(payload),
+            )
+        if min_logger.isEnabledFor(DEBUG):
+            min_logger.debug(
+                "Sending MIN frame, on wire bytes=%s", bytes_to_hexstr(on_wire_bytes)
+            )
         self._serial_write(on_wire_bytes)
 
     def queue_frame(self, min_id: int, payload: bytes):
@@ -485,7 +487,8 @@ class MINTransport:
         Called by handler to pass over a sequence of bytes
         :param data:
         """
-        min_logger.debug("Received bytes: %s", bytes_to_hexstr(data))
+        if min_logger.isEnabledFor(DEBUG):
+            min_logger.debug("Received bytes: %s", bytes_to_hexstr(data))
         for byte in data:
             if self._rx_header_bytes_seen == 2:
                 self._rx_header_bytes_seen = 0
@@ -701,15 +704,14 @@ class MINTransport:
             # Frames still to send
             frame = self._transport_fifo_get(n=window_size)
             frame.seq = self._sn_max
-            self._last_sent_frame_ms = self._now_ms()
-            frame.last_sent_time = self._now_ms()
-            min_logger.debug(
-                "Sending new frame id=0x%02X seq=%d len=%d payload=%s",
-                frame.min_id,
-                frame.seq,
-                len(frame.payload),
-                bytes_to_hexstr(frame.payload),
-            )
+            if min_logger.isEnabledFor(DEBUG):
+                min_logger.debug(
+                    "Sending new frame id=0x%02X seq=%d len=%d payload=%s",
+                    frame.min_id,
+                    frame.seq,
+                    len(frame.payload),
+                    bytes_to_hexstr(frame.payload),
+                )
             self._transport_fifo_send(frame=frame)
             self._sn_max = (self._sn_max + 1) & 0xFF
         else:
@@ -777,8 +779,8 @@ class MINTransportSerial(MINTransport):
     def _serial_write(self, data: bytes):
         if self.fake_errors:
             data = self._corrupted_data(data)
-
-        min_logger.debug("_serial_write: %s", bytes_to_hexstr(data))
+        if min_logger.isEnabledFor(DEBUG):
+            min_logger.debug("_serial_write: %s", bytes_to_hexstr(data))
         self._serial.write(data)
 
     def _serial_any(self):

--- a/host/min.py
+++ b/host/min.py
@@ -663,12 +663,13 @@ class MINTransport:
         if len(self._transport_fifo) == 0:
             raise AssertionError
 
+        now_ms = self._now_ms()
         window_size = (self._sn_max - self._sn_min) & 0xFF
         oldest_frame = self._transport_fifo[0]  # type: MINFrame
-        longest_elapsed_time = self._now_ms() - oldest_frame.last_sent_time
+        longest_elapsed_time = now_ms - oldest_frame.last_sent_time
 
         for i in range(window_size):
-            elapsed = self._now_ms() - self._transport_fifo[i].last_sent_time
+            elapsed = now_ms - self._transport_fifo[i].last_sent_time
             if elapsed >= longest_elapsed_time:
                 oldest_frame = self._transport_fifo[i]
                 longest_elapsed_time = elapsed
@@ -683,11 +684,12 @@ class MINTransport:
 
         :return: array of accepted MIN frames
         """
+        now_ms = self._now_ms()
         remote_connected = (
-            self._now_ms() - self._last_received_anything_ms
+            now_ms - self._last_received_anything_ms
         ) < self.idle_timeout_ms
         remote_active = (
-            self._now_ms() - self._last_received_frame_ms
+            now_ms - self._last_received_frame_ms
         ) < self.idle_timeout_ms
 
         self._rx_list = []
@@ -704,6 +706,8 @@ class MINTransport:
             # Frames still to send
             frame = self._transport_fifo_get(n=window_size)
             frame.seq = self._sn_max
+            self._last_sent_frame_ms = now_ms
+            frame.last_sent_time = now_ms
             if min_logger.isEnabledFor(DEBUG):
                 min_logger.debug(
                     "Sending new frame id=0x%02X seq=%d len=%d payload=%s",
@@ -719,7 +723,7 @@ class MINTransport:
             if window_size > 0 and remote_connected:
                 oldest_frame = self._find_oldest_frame()
                 if (
-                    self._now_ms() - oldest_frame.last_sent_time
+                    now_ms - oldest_frame.last_sent_time
                     > self.frame_retransmit_timeout_ms
                 ):
                     min_logger.debug(
@@ -731,7 +735,7 @@ class MINTransport:
 
         # Periodically transmit ACK
         if (
-            self._now_ms() - self._last_sent_ack_time_ms
+            now_ms - self._last_sent_ack_time_ms
             > self.ack_retransmit_timeout_ms
         ):
             if remote_active:


### PR DESCRIPTION
I found these bottlenecks while profiling my python application based on the min host using [pyspeedscope](https://github.com/windelbouwman/pyspeedscope). My application uploads firmware to a microcontroller and I was able to improve throughput by about 10% with these modifications.

Regarding commit `perf(host): speed up bytes_to_hexstr up to 100x`, here's quick benchmark test:


```python
# test.py

import time

def bytes_to_hexstr_OLD(bytesequence: bytes) -> str:
    return "".join(f"{b:02X}" for b in bytesequence)

def bytes_to_hexstr_NEW(bytesequence: bytes) -> str:
    return bytesequence.hex().upper()

def timeit(f):
    start_time = time.time()
    f()
    end_time = time.time()
    return end_time - start_time

def test_case(bytesequence_size, run_count):
    input = bytes([i % 256 for i in range(bytesequence_size)])
    time1 = sum(timeit(lambda: bytes_to_hexstr_OLD(input))
                for _ in range(run_count)) / run_count
    time2 = sum(timeit(lambda: bytes_to_hexstr_NEW(input))
                for _ in range(run_count)) / run_count
    print(
        f"NEW vs. OLD {time1 / time2:.2f}x faster (bytesequence_size={bytesequence_size}, run_count={run_count})")

test_case(256, 1)
test_case(256, 10)
test_case(256, 100)
test_case(256, 1000)
test_case(256, 10000)
test_case(256*256, 1)
test_case(256*256, 10)
test_case(256*256, 100)
test_case(256*256, 1000)
```

```
python3 --version
Python 3.10.12
python3 test.py
NEW vs. OLD 4.44x faster (bytesequence_size=256, run_count=1)
NEW vs. OLD 63.05x faster (bytesequence_size=256, run_count=10)
NEW vs. OLD 60.77x faster (bytesequence_size=256, run_count=100)
NEW vs. OLD 77.76x faster (bytesequence_size=256, run_count=1000)
NEW vs. OLD 68.41x faster (bytesequence_size=256, run_count=10000)
NEW vs. OLD 127.16x faster (bytesequence_size=65536, run_count=1)
NEW vs. OLD 105.42x faster (bytesequence_size=65536, run_count=10)
NEW vs. OLD 122.96x faster (bytesequence_size=65536, run_count=100)
NEW vs. OLD 119.90x faster (bytesequence_size=65536, run_count=1000)
```